### PR TITLE
Add cookieName to ReadMe guide example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ async function handler(req, res) {
 
 export default withIronSession(handler, {
   password: "complex_password_at_least_32_characters_long",
+  cookieName: "myapp_cookiename",
   // if your localhost is served on http:// then disable the secure flag
   cookieOptions: {
     secure: process.env.NODE_ENV === "production",
@@ -100,6 +101,7 @@ function handler(req, res, session) {
 
 export default withIronSession(handler, {
   password: "complex_password_at_least_32_characters_long",
+  cookieName: "myapp_cookiename",
   // if your localhost is served on http:// then disable the secure flag
   cookieOptions: {
     secure: process.env.NODE_ENV === "production",
@@ -119,6 +121,7 @@ function handler(req, res, session) {
 
 export default withIronSession(handler, {
   password: "complex_password_at_least_32_characters_long",
+  cookieName: "myapp_cookiename",
   // if your localhost is served on http:// then disable the secure flag
   cookieOptions: {
     secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
The API requires cookieName to be passed to withIronSession() so including it in the ReadMe guide files.